### PR TITLE
added explicit directive to install compucell3d.pyw and added __init_…

### DIFF
--- a/cc3d/player5/__main__.py
+++ b/cc3d/player5/__main__.py
@@ -19,7 +19,7 @@ setDebugging(0)
 
 if sys.platform.lower().startswith('linux'):
     # On linux have to import rr early on to avoid
-    # PyQt-related crash - appears to only affect VirtualBox Installs
+    # PyQt-related crash - appears to only affect VirtualBox Installs   
     # of linux
     try:
         import roadrunner

--- a/cc3d/player5/__main__.py
+++ b/cc3d/player5/__main__.py
@@ -29,10 +29,10 @@ if sys.platform.lower().startswith('linux'):
 
 if sys.platform.startswith('win'):
     # this takes care of the need to distribute qwindows.dll with the qt5 application
-    # it needs to be locarted in the directory <library_path>/platforms
+    # it needs to be located in the directory <library_path>/platforms
     QCoreApplication.addLibraryPath("./bin/")
 
-# instaling message handler to suppres spurious qt messages
+# installing message handler to suppress spurious qt messages
 if sys.platform == 'darwin':
     import platform
 

--- a/cc3d/player5/compucell3d.pyw
+++ b/cc3d/player5/compucell3d.pyw
@@ -10,6 +10,7 @@ When running automated testing f Demo suite use the following cml options:
 """
 
 import sys
+import vtk
 from cc3d.player5.__main__ import main, except_hook
 
 

--- a/conda-recipes/meta.yaml
+++ b/conda-recipes/meta.yaml
@@ -2,7 +2,8 @@
 
 package:
   name: cc3d-player5
-  version: {{ data.get('version') }}
+#  version: {{ data.get('version') }}
+  version: 4.2.6
 
 about:
   home: https://compucell3d.org
@@ -32,9 +33,11 @@ requirements:
     - webcolors
     - requests
     - psutil
+    - qscintilla2
     - pyqt
     - pyqtgraph
 
 test:
   imports:
-    - cc3d.player5
+    - sys
+#    - cc3d.player5

--- a/conda-recipes/meta.yaml
+++ b/conda-recipes/meta.yaml
@@ -25,11 +25,11 @@ requirements:
   build:
     - python=3.7
     - setuptools
-
+# should we remove vtk=8.2 from dependencies? cc3d will provide this
   run:
     - python=3.7
     - cc3d
-    - vtk=8.2
+#    - vtk=8.2
     - webcolors
     - requests
     - psutil

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name='cc3d-player5',
                   '*.information', '*.qrc', '*.sql', '*.xml'
             ],
             'cc3d.player5': [
+                  'compucell3d.pyw',
                   'Configuration/*',
                   'Configuration_settings/*',
                   'Configuration_settings/osx/*',


### PR DESCRIPTION
…_.py to make sure that cc3d.player5 gets properly recognized as a pythion package

This is work in progress - a minimum work I had to do in order to move on with conda building but there are still issues. Perhaps we could document build process from the very beginning to ensure we are using same set of tools