### PR TITLE
fixing configuration dialog float to in cast - needed on windows with…

### DIFF
--- a/cc3d/player5/Configuration/ConfigurationDialog.py
+++ b/cc3d/player5/Configuration/ConfigurationDialog.py
@@ -295,7 +295,7 @@ class ConfigurationDialog(QDialog, ui_configurationdlg.Ui_CC3DPrefs, Configurati
         self.numberOfContoursLinesSpinBox.setValue(val)
 
         val = field_params_dict["ArrowLength"]
-        self.vectorsArrowLength.setValue(val)
+        self.vectorsArrowLength.setValue(int(val))
         val = field_params_dict["ScaleArrowsOn"]
         self.vectorsScaleArrowCheckBox.setChecked(val)
         val = field_params_dict["FixedArrowColorOn"]


### PR DESCRIPTION
… latest qt/pyqt

This PR might have more commits but for now, this simple fix seems to get the job done (only Windows is affected)