### PR TITLE
Bugfix: Graceful exit when closing Player

### DIFF
--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -1140,10 +1140,7 @@ class SimpleTabView(MainArea, SimpleViewManager):
             reply = QMessageBox.question(self, 'CC3D Player',
                 "Are you sure to quit?", QMessageBox.Yes, QMessageBox.Cancel)
             
-            if reply == QMessageBox.Yes:
-                # self.__simulationStop()
-                pass
-            else:
+            if reply != QMessageBox.Yes:
                 #Cancel exit
                 event.ignore()
                 return

--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -1137,7 +1137,7 @@ class SimpleTabView(MainArea, SimpleViewManager):
 
         if self.simulationIsRunning or \
           (self.simulationIsStepping and not self.simulation.getStopSimulation()):
-            reply = QMessageBox.question(self, '',
+            reply = QMessageBox.question(self, 'CC3D Player',
                 "Are you sure to quit?", QMessageBox.Yes, QMessageBox.Cancel)
             
             if reply == QMessageBox.Yes:

--- a/cc3d/player5/Simulation/SimulationThread.py
+++ b/cc3d/player5/Simulation/SimulationThread.py
@@ -396,6 +396,10 @@ class SimulationThread(QtCore.QThread, SimulationThreadBase):
         self.inject()
         run_cc3d_project(cc3d_sim_fname=cc3d_sim_fname)
 
+    def quit(self):
+        super()
+        self.finishRequest.emit(True)
+
     @staticmethod
     def main_loop():
         player_type = CompuCellSetup.persistent_globals.player_type


### PR DESCRIPTION
This fixes the error `QThread: Destroyed while thread is still running` that occurred in the following situation:

1. Start a simulation (either through the Play button or the Step button)
2. Rather than clicking Stop, hit the X to close the Player window