### PR TITLE
Added support for in-memory cache for settings. this way get and set …

### DIFF
--- a/cc3d/player5/Configuration/__init__.py
+++ b/cc3d/player5/Configuration/__init__.py
@@ -135,15 +135,55 @@ def setUsedFieldNames(fieldNamesList):
     setSetting('FieldParams', cleanedFieldParams)
 
 
+def _ensure_settings_storage(settings_obj, settings_path, load_fcn):
+    if settings_obj is None:
+        if settings_path:
+            return load_fcn(settings_path)
+        return None, settings_path
+
+    if getattr(settings_obj, 'conn', None) is None:
+        return load_fcn(settings_path)
+
+    return settings_obj, settings_path
+
+
+def _write_settings_storage(settings_obj):
+    if settings_obj is None:
+        return
+
+    on_close_fcn = getattr(settings_obj, 'on_close', None)
+    if on_close_fcn is not None:
+        on_close_fcn()
+    else:
+        settings_obj.close()
+
+
 def writeAllSettings():
     """
-    Kept to satisfy legacy API - not needed with sql-based settings
+    Flushes in-memory settings caches to the backing sqlite files.
     :return: None
     """
-    pass
+    Configuration.myGlobalSettings, Configuration.myGlobalSettingsPath = _ensure_settings_storage(
+        settings_obj=Configuration.myGlobalSettings,
+        settings_path=Configuration.myGlobalSettingsPath,
+        load_fcn=loadSettings if Configuration.myGlobalSettingsPath else loadGlobalSettings
+    )
+    _write_settings_storage(Configuration.myGlobalSettings)
 
 
-def writeSettingsForSingleSimulation(path):
+    if Configuration.myCustomSettingsPath:
+        Configuration.myCustomSettings, Configuration.myCustomSettingsPath = _ensure_settings_storage(
+            settings_obj=Configuration.myCustomSettings,
+            settings_path=Configuration.myCustomSettingsPath,
+            load_fcn=loadSettings
+        )
+        _write_settings_storage(Configuration.myCustomSettings)
+    else:
+        Configuration.myCustomSettings = None
+        Configuration.myCustomSettingsPath = ''
+
+
+def load_or_create_simulation_settings(path):
     """
     Here we are creating settings for a single simulation or loading them if they already exist
     :param path: {src} abs path to local settings

--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -1092,7 +1092,7 @@ class SimpleTabView(MainArea, SimpleViewManager):
                 os.path.join(self.cc3dSimulationDataHandler.cc3dSimulationData.basePath, 'Simulation',
                              settings_data.SETTINGS_FILE_NAME))
 
-            Configuration.writeSettingsForSingleSimulation(self.customSettingPath)
+            Configuration.load_or_create_simulation_settings(self.customSettingPath)
 
     def __setConnects(self):
         """
@@ -2477,20 +2477,22 @@ class SimpleTabView(MainArea, SimpleViewManager):
         # self.__save_windows_layout()
         # saving settings with the simulation
 
+        # Since we cache settings in memory for the duration of simulation, first thing we must do after the
+        # simulation is over is to write memory content to the DB because at this point  on-disk db must
+        # be storing the  updated settings
+        Configuration.writeAllSettings()
+        Configuration.initConfiguration()
+
+        # we will be copying updated settings here
         pg.copy_custom_settings_to_output_folder()
 
         if self.customSettingPath:
             if self.restore_default_settings_local_flag:
                 Configuration.replace_custom_settings_with_defaults()
             else:
-                Configuration.writeSettingsForSingleSimulation(self.customSettingPath)
+                Configuration.load_or_create_simulation_settings(self.customSettingPath)
 
             self.customSettingPath = ''
-
-        Configuration.writeAllSettings()
-        Configuration.initConfiguration()  # this flushes configuration
-        # copy _ettings.sqlite to the output simulation folder
-
 
         if Configuration.getSetting("ClosePlayerAfterSimulationDone") or self.closePlayerAfterSimulationDone:
             Configuration.setSetting("RecentFile", os.path.abspath(self.__sim_file_name))
@@ -2498,6 +2500,8 @@ class SimpleTabView(MainArea, SimpleViewManager):
             Configuration.setSetting("RecentSimulations", os.path.abspath(self.__sim_file_name))
 
             # sys.exit(_exitCode)
+
+
             CompuCellSetup.resetGlobals()
             self.quit()
 


### PR DESCRIPTION
…operations are instantaneous - no disks write while the simulation is running, and we write updated settings at the end of the simulation. 
Users reported issues when running multiple simulations, so this fix should help