### PR TITLE
Relegated error display to a popup windows away from the error console

### DIFF
--- a/cc3d/player5/CQt/CQApplication.py
+++ b/cc3d/player5/CQt/CQApplication.py
@@ -1,6 +1,7 @@
 
 import os
 import sys
+import traceback
 # from PyQt5.QtCore import QEvent, Qt
 from PyQt5.QtWidgets import QApplication
 
@@ -13,6 +14,32 @@ class CQApplication(QApplication):
         QApplication.__init__(self, argv)
         self.__objectRegistry = {}
         self.__pluginObjectRegistry = {}
+        self._handling_gui_exception = False
+
+    def notify(self, receiver, event):
+        try:
+            return QApplication.notify(self, receiver, event)
+        except Exception as exc:
+            traceback.print_exc()
+
+            if self._handling_gui_exception:
+                return False
+
+            self._handling_gui_exception = True
+            try:
+                from cc3d.player5.Utilities import show_exception_messagebox
+
+                parent = self.activeWindow()
+                show_exception_messagebox(
+                    title="Player Error",
+                    message="An unexpected error occurred while handling a GUI callback.",
+                    exception=exc,
+                    parent=parent,
+                )
+            finally:
+                self._handling_gui_exception = False
+
+            return False
         
     def registerObject(self, name, object):
         """

--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -51,6 +51,7 @@ from cc3d.CompuCellSetup.simulation_utils import str_to_int_container
 from cc3d.CompuCellSetup.utils import SCREENSHOT_SUBDIR
 from typing import Union, Optional
 from cc3d.player5.Utilities.unzipper import Unzipper
+from cc3d.player5.Utilities import show_formatted_error_messagebox
 from weakref import ref
 from subprocess import Popen
 from cc3d.player5.Utilities.terminal import Terminal
@@ -833,30 +834,23 @@ class SimpleTabView(MainArea, SimpleViewManager):
 
     def handleErrorMessage(self, _errorType, _traceback_message) -> None:
         """
-        Callback function used to display any type of errors from the simulation script
+        Callback function used to display any type of errors from the simulation script.
+        Errors are shown in a popup without forcing the syntax error console to open.
 
         :param _errorType: str - error type
         :param _traceback_message: str - contains full Python traceback
         :return: None
         """
-        msg = QMessageBox.warning(self, _errorType,
-                                  _traceback_message,
-                                  QMessageBox.Ok,
-                                  QMessageBox.Ok)
+        show_formatted_error_messagebox(
+            error_text=_traceback_message,
+            parent=self,
+        )
 
         self.__cleanAfterSimulation()
-        print('errorType=', _errorType)
-        syntax_error_console = self.UI.console.get_syntax_error_console()
-        # console = self.UI.console
-        text = "Search \"file.xml\"\n"
-        text += "    file.xml\n"
-        text += _traceback_message
-        syntax_error_console.setText(text)
-        # console.set_stderr_content(text)
 
     def handleErrorFormatted(self, _errorMessage):
         """
-        Pastes errorMessage directly into error console
+        Handles preformatted simulation errors without activating the error console.
 
         :param _errorMessage: str with error message
         :return: None
@@ -864,10 +858,11 @@ class SimpleTabView(MainArea, SimpleViewManager):
         CompuCellSetup.error_code = 1
 
         self.__cleanAfterSimulation()
-        syntax_error_console = self.UI.console.get_syntax_error_console()
 
-        syntax_error_console.setText(_errorMessage)
-        self.UI.console.bring_up_syntax_error_console()
+        show_formatted_error_messagebox(
+            error_text=_errorMessage,
+            parent=self,
+        )
 
         if self.cml_args.testOutputDir:
             with open(os.path.join(self.cml_args.testOutputDir, 'error_output.txt'), 'w') as fout:

--- a/cc3d/player5/UI/CC3DSender.py
+++ b/cc3d/player5/UI/CC3DSender.py
@@ -273,25 +273,6 @@ class CC3DSender(QObject):
             self.errorConsole.emitCloseCC3D()
             return
 
-            # import sys
-
-            # sys.exit()
-            # self.errorConsole.closeCC3D()
-            # self.socket.flush()
-            # self.socket.disconnectFromHost()
-            # self.socket.close()
-            # self.socket=None
-            # return
-
-            QMessageBox.information(None, "EDITOR WAS CLOSED", "EDITOR CLOSED: ")
-            reply = QByteArray()
-            stream1 = QDataStream(reply, QIODevice.WriteOnly)
-            stream1.setVersion(QDataStream.Qt_5_2)
-            stream1.writeUInt16(0)
-            # self.socket.close()
-            self.socket.write(reply)
-
-
         elif messageType == "EDITOROPEN":
             print("GOT EDITOROPEN MESSAGE")
             if self.editorMessageBox:

--- a/cc3d/player5/Utilities/utils.py
+++ b/cc3d/player5/Utilities/utils.py
@@ -9,7 +9,8 @@ from PyQt5.QtGui import QColor, QDesktopServices
 from PyQt5.QtCore import Qt, QUrl
 import traceback
 from functools import wraps
-from PyQt5.QtWidgets import QMessageBox, QLabel, QTextEdit
+from PyQt5.QtWidgets import QMessageBox, QLabel, QTextEdit, QDialog, QDialogButtonBox, QVBoxLayout, QHBoxLayout, QStyle
+import html
 import sys
 
 cell_type_color_props = namedtuple('cell_type_color_props', 'color type_name invisible')
@@ -24,6 +25,143 @@ def get_monospace_font_stack():
     else:
         return "DejaVu Sans Mono, Liberation Mono, monospace"
 
+
+def _build_traceback_html(traceback_text: str) -> str:
+    line_html = []
+
+    for raw_line in traceback_text.splitlines():
+        escaped_line = html.escape(raw_line)
+        stripped_line = raw_line.strip()
+
+        if raw_line.startswith("Traceback"):
+            color = "#c7922b"
+            font_weight = "700"
+        elif stripped_line.startswith('File "'):
+            color = "#4f8cc9"
+            font_weight = "600"
+        elif raw_line.startswith("    "):
+            color = "#d8dee9"
+            font_weight = "400"
+        elif stripped_line and not raw_line.startswith(" "):
+            color = "#ff8a80"
+            font_weight = "700"
+        else:
+            color = "#d8dee9"
+            font_weight = "400"
+
+        line_html.append(
+            f"<span style='color: {color}; font-weight: {font_weight};'>{escaped_line}</span>"
+        )
+
+    return "<br>".join(line_html) if line_html else "<span style='color: #d8dee9;'>No traceback available.</span>"
+
+
+class ErrorDetailsDialog(QDialog):
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        informative_text: str = "",
+        detailed_text: str = "",
+        parent=None,
+    ):
+        super().__init__(parent)
+
+        self._compact_size = (900, 170)
+        self._expanded_size = (900, 560)
+
+        self.setWindowTitle(title)
+        self.setModal(True)
+        self.resize(*self._compact_size)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 10, 14, 12)
+        layout.setSpacing(8)
+
+        header_layout = QHBoxLayout()
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(8)
+
+        icon_label = QLabel(self)
+        icon_pixmap = self.style().standardIcon(QStyle.SP_MessageBoxCritical).pixmap(32, 32)
+        icon_label.setPixmap(icon_pixmap)
+        icon_label.setAlignment(Qt.AlignVCenter | Qt.AlignHCenter)
+        header_layout.addWidget(icon_label, 0, Qt.AlignVCenter)
+
+        title_label = QLabel(f"<b>{message}</b>", self)
+        title_label.setWordWrap(True)
+        title_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        title_label.setAlignment(Qt.AlignVCenter | Qt.AlignLeft)
+        title_label.setContentsMargins(0, 0, 0, 0)
+        header_layout.addWidget(title_label, 1, Qt.AlignVCenter)
+        layout.addLayout(header_layout)
+
+        if informative_text:
+            info_label = QLabel(self)
+            info_label.setWordWrap(True)
+            info_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+            info_label.setStyleSheet(
+                "QLabel {"
+                "background: #fff8e1;"
+                "border: 1px solid #e6cf8b;"
+                "border-radius: 6px;"
+                "padding: 6px 8px;"
+                "color: #3a3122;"
+                "}"
+            )
+            info_label.setText(
+                f"<pre style='margin: 0; font-family: {get_monospace_font_stack()};'>"
+                f"{html.escape(informative_text)}"
+                f"</pre>"
+            )
+            layout.addWidget(info_label)
+
+        self.details_edit = QTextEdit(self)
+        self.details_edit.setReadOnly(True)
+        self.details_edit.setAcceptRichText(True)
+        self.details_edit.setStyleSheet(
+            "QTextEdit {"
+            "background: #1f2430;"
+            "color: #d8dee9;"
+            "border: 1px solid #394150;"
+            "border-radius: 8px;"
+            "padding: 8px;"
+            "}"
+        )
+        self.details_edit.document().setDefaultStyleSheet(
+            "body {"
+            f"font-family: {get_monospace_font_stack()};"
+            "font-size: 11pt;"
+            "line-height: 1.35;"
+            "}"
+        )
+        self.details_edit.setHtml(
+            "<body>"
+            f"{_build_traceback_html(detailed_text)}"
+            "</body>"
+        )
+        self.details_edit.setVisible(False)
+        has_details = bool(detailed_text.strip())
+        layout.addWidget(self.details_edit, 1)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok, parent=self)
+        self.details_button = None
+        if has_details:
+            self.details_button = button_box.addButton("Show More", QDialogButtonBox.ActionRole)
+            self.details_button.clicked.connect(self._toggle_details)
+        button_box.accepted.connect(self.accept)
+        layout.addWidget(button_box)
+
+    def _toggle_details(self):
+        showing_details = self.details_edit.isVisible()
+        self.details_edit.setVisible(not showing_details)
+
+        if self.details_button is not None:
+            self.details_button.setText("Show Less" if not showing_details else "Show More")
+
+        self.resize(*(self._expanded_size if not showing_details else self._compact_size))
+
+
 def show_exception_messagebox(
     title: str,
     message: str,
@@ -33,49 +171,14 @@ def show_exception_messagebox(
     tb_str = "".join(traceback.format_exception(
         type(exception), exception, exception.__traceback__)
     )
-
-    msg = QMessageBox(parent)
-
-    msg.setIcon(QMessageBox.Critical)
-    msg.setWindowTitle(title)
-
-    msg.setText(f"<b>{message}</b>")
-    font_stack = get_monospace_font_stack()
-
-    msg.setInformativeText(
-        f"<pre style='font-family: {font_stack};'>"
-        f"{str(exception)}</pre>"
+    dialog = ErrorDetailsDialog(
+        title=title,
+        message=message,
+        informative_text=str(exception),
+        detailed_text=tb_str,
+        parent=parent,
     )
-
-    msg.setDetailedText(tb_str)
-
-    msg.setStandardButtons(QMessageBox.Ok)
-
-    msg.setTextInteractionFlags(Qt.TextSelectableByMouse)
-
-    # ---- FORCE WIDER DIALOG ----
-    desired_width = 800
-
-    # Resize main dialog
-    msg.resize(desired_width, msg.sizeHint().height())
-
-    # Resize internal label
-    label = msg.findChild(QLabel, "qt_msgbox_label")
-    if label:
-        label.setMinimumWidth(desired_width)
-
-    # Resize informative label
-    info_label = msg.findChild(QLabel, "qt_msgbox_informativelabel")
-    if info_label:
-        info_label.setMinimumWidth(desired_width)
-
-    # Resize detailed traceback area
-    text_edit = msg.findChild(QTextEdit)
-    if text_edit:
-        text_edit.setMinimumWidth(desired_width)
-        text_edit.setMinimumHeight(300)
-
-    msg.exec_()
+    dialog.exec_()
 
 
 def show_text_messagebox(
@@ -85,42 +188,14 @@ def show_text_messagebox(
     detailed_text: str = "",
     parent=None,
 ):
-    msg = QMessageBox(parent)
-
-    msg.setIcon(QMessageBox.Critical)
-    msg.setWindowTitle(title)
-    msg.setText(f"<b>{message}</b>")
-
-    if informative_text:
-        font_stack = get_monospace_font_stack()
-        msg.setInformativeText(
-            f"<pre style='font-family: {font_stack};'>"
-            f"{informative_text}</pre>"
-        )
-
-    if detailed_text:
-        msg.setDetailedText(detailed_text)
-
-    msg.setStandardButtons(QMessageBox.Ok)
-    msg.setTextInteractionFlags(Qt.TextSelectableByMouse)
-
-    desired_width = 800
-    msg.resize(desired_width, msg.sizeHint().height())
-
-    label = msg.findChild(QLabel, "qt_msgbox_label")
-    if label:
-        label.setMinimumWidth(desired_width)
-
-    info_label = msg.findChild(QLabel, "qt_msgbox_informativelabel")
-    if info_label:
-        info_label.setMinimumWidth(desired_width)
-
-    text_edit = msg.findChild(QTextEdit)
-    if text_edit:
-        text_edit.setMinimumWidth(desired_width)
-        text_edit.setMinimumHeight(300)
-
-    msg.exec_()
+    dialog = ErrorDetailsDialog(
+        title=title,
+        message=message,
+        informative_text=informative_text,
+        detailed_text=detailed_text,
+        parent=parent,
+    )
+    dialog.exec_()
 
 
 def show_formatted_error_messagebox(error_text: str, parent=None):

--- a/cc3d/player5/Utilities/utils.py
+++ b/cc3d/player5/Utilities/utils.py
@@ -50,10 +50,12 @@ def _build_traceback_html(traceback_text: str) -> str:
             font_weight = "400"
 
         line_html.append(
-            f"<span style='color: {color}; font-weight: {font_weight};'>{escaped_line}</span>"
+            f"<span style='color: {color}; font-weight: {font_weight}; white-space: pre-wrap;'>{escaped_line}</span>"
         )
 
-    return "<br>".join(line_html) if line_html else "<span style='color: #d8dee9;'>No traceback available.</span>"
+    return "<br>".join(line_html) if line_html else (
+        "<span style='color: #d8dee9; white-space: pre-wrap;'>No traceback available.</span>"
+    )
 
 
 class ErrorDetailsDialog(QDialog):
@@ -133,6 +135,7 @@ class ErrorDetailsDialog(QDialog):
             f"font-family: {get_monospace_font_stack()};"
             "font-size: 11pt;"
             "line-height: 1.35;"
+            "white-space: pre-wrap;"
             "}"
         )
         self.details_edit.setHtml(

--- a/cc3d/player5/Utilities/utils.py
+++ b/cc3d/player5/Utilities/utils.py
@@ -78,6 +78,64 @@ def show_exception_messagebox(
     msg.exec_()
 
 
+def show_text_messagebox(
+    title: str,
+    message: str,
+    informative_text: str = "",
+    detailed_text: str = "",
+    parent=None,
+):
+    msg = QMessageBox(parent)
+
+    msg.setIcon(QMessageBox.Critical)
+    msg.setWindowTitle(title)
+    msg.setText(f"<b>{message}</b>")
+
+    if informative_text:
+        font_stack = get_monospace_font_stack()
+        msg.setInformativeText(
+            f"<pre style='font-family: {font_stack};'>"
+            f"{informative_text}</pre>"
+        )
+
+    if detailed_text:
+        msg.setDetailedText(detailed_text)
+
+    msg.setStandardButtons(QMessageBox.Ok)
+    msg.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+    desired_width = 800
+    msg.resize(desired_width, msg.sizeHint().height())
+
+    label = msg.findChild(QLabel, "qt_msgbox_label")
+    if label:
+        label.setMinimumWidth(desired_width)
+
+    info_label = msg.findChild(QLabel, "qt_msgbox_informativelabel")
+    if info_label:
+        info_label.setMinimumWidth(desired_width)
+
+    text_edit = msg.findChild(QTextEdit)
+    if text_edit:
+        text_edit.setMinimumWidth(desired_width)
+        text_edit.setMinimumHeight(300)
+
+    msg.exec_()
+
+
+def show_formatted_error_messagebox(error_text: str, parent=None):
+    error_text = error_text or ""
+    lines = [line.strip() for line in error_text.splitlines() if line.strip()]
+    informative_text = lines[0] if lines else "Unknown Player error"
+
+    show_text_messagebox(
+        title="Player Error",
+        message="A simulation error occurred.",
+        informative_text=informative_text,
+        detailed_text=error_text,
+        parent=parent,
+    )
+
 
 def safe_callback(func):
     @wraps(func)

--- a/cc3d/player5/__main__.py
+++ b/cc3d/player5/__main__.py
@@ -6,6 +6,7 @@ import sys
 from cc3d import player5
 from cc3d.player5.CMLParser import CMLParser
 from cc3d.player5.UI.UserInterface import UserInterface
+from cc3d.player5.Utilities import show_exception_messagebox
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -17,6 +18,8 @@ import cc3d
 from cc3d.player5.styles.StyleManager import subscribe_to_style_sheet
 
 setDebugging(0)
+
+_handling_global_gui_exception = False
 
 if sys.platform.lower().startswith('linux'):
     # On linux have to import rr early on to avoid
@@ -125,7 +128,24 @@ def main(argv=None):
 
 
 def except_hook(cls, exception, traceback):
+    global _handling_global_gui_exception
+
     sys.__excepthook__(cls, exception, traceback)
+
+    app = QApplication.instance()
+    if app is not None and not _handling_global_gui_exception:
+        _handling_global_gui_exception = True
+        try:
+            show_exception_messagebox(
+                title="Player Error",
+                message="An unexpected error occurred while handling a GUI callback.",
+                exception=exception,
+                parent=app.activeWindow(),
+            )
+        finally:
+            _handling_global_gui_exception = False
+        return
+
     sys.exit(1)
 
 


### PR DESCRIPTION
Switched to popup dialog to display simulation errors/tracebacks:
<img width="1337" height="656" alt="image" src="https://github.com/user-attachments/assets/9a595880-877a-40d0-aa00-df7d7bb17cb3" />
<img width="1025" height="582" alt="image" src="https://github.com/user-attachments/assets/03ac703e-7d4a-4f6c-bc0f-1b089e348178" />
Also, added global hook that intercepts all errors from the player code to display in the popup dialog
